### PR TITLE
refactor: implement native HTML Popover API with graceful fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/lion-lef/col-cal/issues/3
-Your prepared branch: issue-3-8f54426e510b
-Your prepared working directory: /tmp/gh-issue-solver-1770102467760
-Your forked repository: konard/lion-lef-col-cal
-Original repository (upstream): lion-lef/col-cal
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/lion-lef/col-cal/issues/3
+Your prepared branch: issue-3-8f54426e510b
+Your prepared working directory: /tmp/gh-issue-solver-1770102467760
+Your forked repository: konard/lion-lef-col-cal
+Original repository (upstream): lion-lef/col-cal
+
+Proceed.

--- a/examples/native-popover-demo.html
+++ b/examples/native-popover-demo.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Native Popover API Demo - Col-Cal</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            padding: 40px;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: #333;
+        }
+
+        .demo-section {
+            margin: 40px 0;
+            padding: 20px;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+        }
+
+        .demo-section h2 {
+            margin-top: 0;
+            color: #555;
+        }
+
+        .feature-status {
+            padding: 10px 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            font-weight: 500;
+        }
+
+        .feature-status.supported {
+            background-color: #d4edda;
+            color: #155724;
+        }
+
+        .feature-status.not-supported {
+            background-color: #fff3cd;
+            color: #856404;
+        }
+
+        .calendar-container {
+            margin-top: 20px;
+        }
+
+        code {
+            background: #f5f5f5;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.9em;
+        }
+
+        pre {
+            background: #f5f5f5;
+            padding: 16px;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+
+        .api-feature {
+            display: flex;
+            align-items: center;
+            margin: 8px 0;
+        }
+
+        .api-feature .check {
+            color: #28a745;
+            margin-right: 8px;
+        }
+
+        .api-feature .cross {
+            color: #dc3545;
+            margin-right: 8px;
+        }
+    </style>
+    <script type="module" src="../src/index.ts"></script>
+</head>
+<body>
+    <h1>🗓️ Col-Cal Native Popover API Demo</h1>
+
+    <div class="demo-section">
+        <h2>Browser Support Detection</h2>
+        <div id="feature-status" class="feature-status">
+            Checking browser support...
+        </div>
+
+        <div id="api-features"></div>
+    </div>
+
+    <div class="demo-section">
+        <h2>Calendar Component</h2>
+        <p>
+            The calendar uses the <code>col-cal-popover</code> component for the
+            month and year selection dropdowns. Click on the month or year in the
+            header to see the native popover in action.
+        </p>
+
+        <div class="calendar-container">
+            <col-cal locale="en-US"></col-cal>
+        </div>
+    </div>
+
+    <div class="demo-section">
+        <h2>Native Popover Features Used</h2>
+        <ul>
+            <li><strong>popover="auto"</strong> - Automatic light-dismiss behavior</li>
+            <li><strong>:popover-open</strong> - CSS pseudo-selector for styling open state</li>
+            <li><strong>popovertarget</strong> - Declarative trigger connection</li>
+            <li><strong>popovertargetaction="toggle"</strong> - Toggle behavior on click</li>
+            <li><strong>showPopover()</strong> / <strong>hidePopover()</strong> - Programmatic control</li>
+            <li><strong>toggle event</strong> - State change notifications</li>
+        </ul>
+    </div>
+
+    <div class="demo-section">
+        <h2>Usage Example</h2>
+        <pre><code>&lt;!-- HTML --&gt;
+&lt;col-cal locale="en-US"&gt;&lt;/col-cal&gt;
+
+&lt;!-- JavaScript (ESM) --&gt;
+&lt;script type="module"&gt;
+  import "col-cal";
+  import { supportsPopoverAPI } from "col-cal";
+
+  // Check for native popover support
+  if (supportsPopoverAPI()) {
+    console.log("Using native Popover API");
+  } else {
+    console.log("Using fallback popover");
+  }
+&lt;/script&gt;</code></pre>
+    </div>
+
+    <script type="module">
+        // Feature detection for Popover API
+        function supportsPopoverAPI() {
+            return (
+                typeof HTMLElement !== "undefined" &&
+                "popover" in HTMLElement.prototype &&
+                typeof HTMLElement.prototype.showPopover === "function" &&
+                typeof HTMLElement.prototype.hidePopover === "function"
+            );
+        }
+
+        // Update feature status display
+        const statusEl = document.getElementById("feature-status");
+        const featuresEl = document.getElementById("api-features");
+
+        const features = [
+            { name: "popover attribute", check: "popover" in HTMLElement.prototype },
+            { name: "showPopover()", check: typeof HTMLElement.prototype.showPopover === "function" },
+            { name: "hidePopover()", check: typeof HTMLElement.prototype.hidePopover === "function" },
+            { name: ":popover-open selector", check: supportsPopoverAPI() },
+        ];
+
+        if (supportsPopoverAPI()) {
+            statusEl.className = "feature-status supported";
+            statusEl.innerHTML = "✅ Your browser supports the native Popover API!";
+        } else {
+            statusEl.className = "feature-status not-supported";
+            statusEl.innerHTML = "⚠️ Your browser doesn't support the native Popover API. Using fallback mode.";
+        }
+
+        // Show individual feature support
+        featuresEl.innerHTML = features.map(f => `
+            <div class="api-feature">
+                <span class="${f.check ? 'check' : 'cross'}">${f.check ? '✓' : '✗'}</span>
+                <span>${f.name}</span>
+            </div>
+        `).join("");
+
+        // Set up calendar
+        customElements.whenDefined("col-cal").then(() => {
+            const calendar = document.querySelector("col-cal");
+            if (calendar) {
+                calendar.setAttribute("date", new Date().toISOString());
+            }
+        });
+    </script>
+</body>
+</html>

--- a/src/col-cal-popover/col-cal-popover.css.ts
+++ b/src/col-cal-popover/col-cal-popover.css.ts
@@ -1,7 +1,18 @@
 import { css } from "lit";
 
+/**
+ * Styles for ColCalPopover component.
+ *
+ * This stylesheet uses the native Popover API's :popover-open pseudo-selector
+ * for styling the open state, with fallback styles for browsers that don't
+ * support the Popover API.
+ *
+ * CSS Anchor Positioning is used to position the popover relative to its
+ * anchor element (the trigger button).
+ */
 export const colCalPopoverStyles = css`
   :host {
+    /* CSS Custom Properties for theming */
     --col-cal-popover-bg: #ffffff;
     --col-cal-popover-radius: 8px;
     --col-cal-popover-shadow: 0px 4px 9.8px 0px #0000000d;
@@ -9,7 +20,74 @@ export const colCalPopoverStyles = css`
     --col-cal-popover-gap: 4px;
   }
 
-  .popover-container {
+  /**
+   * Native Popover API Styles
+   *
+   * When using the native popover attribute, the browser handles:
+   * - Top layer placement (no z-index needed)
+   * - Light-dismiss behavior
+   * - Focus management
+   * - Accessibility announcements
+   *
+   * The :popover-open pseudo-selector targets the popover when visible.
+   */
+  .popover-container[popover] {
+    /* Reset browser default popover styles */
+    margin: 0;
+    padding: 0;
+    border: none;
+    overflow: visible;
+    background: transparent;
+
+    /* Use CSS anchor positioning for placement */
+    position-anchor: var(--popover-anchor);
+
+    /* Position below anchor, centered horizontally */
+    top: anchor(bottom);
+    left: anchor(center);
+    translate: -50% 0;
+    margin-top: var(--col-cal-popover-gap);
+
+    /* Fallback: flip above if overflows bottom of viewport */
+    position-try-fallbacks: flip-block;
+
+    /* Hide if no valid anchor position available */
+    position-visibility: anchors-visible;
+  }
+
+  /**
+   * :popover-open pseudo-selector
+   *
+   * This selector matches when the popover is in its open state.
+   * It's automatically applied by the browser when showPopover() is called
+   * or when the popover is triggered via popovertarget.
+   */
+  .popover-container[popover]:popover-open {
+    display: block;
+  }
+
+  /**
+   * Popover content wrapper
+   *
+   * Provides the visual styling (background, shadow, border-radius)
+   * for both native and fallback modes.
+   */
+  .popover-content {
+    background: var(--col-cal-popover-bg);
+    border-radius: var(--col-cal-popover-radius);
+    box-shadow: var(--col-cal-popover-shadow);
+  }
+
+  /**
+   * Fallback Styles
+   *
+   * For browsers that don't support the native Popover API,
+   * these styles provide similar functionality using:
+   * - Fixed positioning with CSS anchor positioning
+   * - data-open attribute for visibility toggle
+   * - Backdrop element for light-dismiss
+   */
+  .popover-container:not([popover]) {
     position: fixed;
     position-anchor: var(--popover-anchor);
     display: none;
@@ -28,16 +106,21 @@ export const colCalPopoverStyles = css`
     position-visibility: anchors-visible;
   }
 
-  .popover-container[data-open] {
+  /**
+   * Fallback open state
+   * Uses data-open attribute since :popover-open isn't available
+   */
+  .popover-container:not([popover])[data-open] {
     display: block;
   }
 
-  .popover-content {
-    background: var(--col-cal-popover-bg);
-    border-radius: var(--col-cal-popover-radius);
-    box-shadow: var(--col-cal-popover-shadow);
-  }
-
+  /**
+   * Backdrop for fallback mode
+   *
+   * Provides light-dismiss functionality by catching clicks outside
+   * the popover content. In native mode, this is handled automatically
+   * by the browser when using popover="auto".
+   */
   .popover-backdrop {
     position: fixed;
     inset: 0;

--- a/src/col-cal-popover/col-cal-popover.ts
+++ b/src/col-cal-popover/col-cal-popover.ts
@@ -1,19 +1,86 @@
 import { LitElement, html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, state, query } from "lit/decorators.js";
 import { colCalPopoverStyles } from "./col-cal-popover.css";
 
+/**
+ * Feature detection for native Popover API support.
+ * The Popover API is available in Chrome 114+, Edge 114+, Safari 17+.
+ * @returns true if the browser supports the native Popover API
+ */
+export function supportsPopoverAPI(): boolean {
+  return (
+    typeof HTMLElement !== "undefined" &&
+    "popover" in HTMLElement.prototype &&
+    typeof HTMLElement.prototype.showPopover === "function" &&
+    typeof HTMLElement.prototype.hidePopover === "function"
+  );
+}
+
+/**
+ * ColCalPopover - A calendar popover component using the native HTML Popover API.
+ *
+ * This component leverages the browser's native popover functionality for better
+ * accessibility, performance, and standards compliance. It uses:
+ * - The `popover="auto"` attribute for automatic light-dismiss behavior
+ * - The `:popover-open` CSS pseudo-selector for styling open state
+ * - CSS anchor positioning for placement relative to trigger elements
+ *
+ * For browsers that don't support the Popover API, it provides graceful
+ * degradation using a JavaScript-based fallback mechanism.
+ *
+ * @fires col-cal-show - Fired when the popover is shown
+ * @fires col-cal-after-hide - Fired when the popover is hidden
+ *
+ * @example
+ * ```html
+ * <button id="trigger">Open Calendar</button>
+ * <col-cal-popover for="trigger">
+ *   <div>Popover content</div>
+ * </col-cal-popover>
+ * ```
+ */
 @customElement("col-cal-popover")
 export class ColCalPopover extends LitElement {
   static styles = colCalPopoverStyles;
 
+  /**
+   * The ID of the anchor element that triggers this popover.
+   * The popover will be positioned relative to this element.
+   */
   @property({ type: String }) for: string = "";
+
+  /**
+   * Data-testid attribute for testing purposes.
+   */
   @property({ type: String }) dataTestid: string = "ColCal-Popover";
 
+  /**
+   * Internal state tracking whether the popover is open.
+   * Used for fallback mode when native popover is not supported.
+   */
   @state()
   private _open: boolean = false;
 
+  /**
+   * Whether native Popover API is supported in this browser.
+   */
+  private _supportsNativePopover: boolean = supportsPopoverAPI();
+
+  /**
+   * Reference to the anchor element that triggers this popover.
+   */
   private _anchorElement: HTMLElement | null = null;
+
+  /**
+   * CSS anchor name for positioning the popover relative to the anchor.
+   */
   private _anchorName: string = "";
+
+  /**
+   * Reference to the popover container element.
+   */
+  @query(".popover-container")
+  private _popoverElement!: HTMLElement;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -25,49 +92,155 @@ export class ColCalPopover extends LitElement {
     this._cleanupAnchor();
   }
 
+  /**
+   * Sets up the anchor element reference and configures the trigger.
+   * In native mode, sets up popovertarget attribute on the anchor.
+   * In fallback mode, adds click event listener.
+   */
   private _setupAnchor(): void {
     requestAnimationFrame(() => {
       if (this.for) {
         const root = this.getRootNode() as Document | ShadowRoot;
         this._anchorElement = root.getElementById(this.for);
         if (this._anchorElement) {
-          // Create unique anchor name from the element's ID
+          // Create unique anchor name from the element's ID for CSS anchor positioning
           this._anchorName = `--anchor-${this.for}`;
-          // Set anchor-name on the target element
+          // Set anchor-name CSS property on the target element
           this._anchorElement.style.setProperty("anchor-name", this._anchorName);
-          this._anchorElement.addEventListener("click", this._handleAnchorClick);
+
+          if (this._supportsNativePopover) {
+            // Use native popovertarget attribute for the trigger
+            // Note: Since we're using Shadow DOM, we need to wait for the
+            // popover element to be rendered before setting up the target
+            this.updateComplete.then(() => {
+              if (this._popoverElement && this._anchorElement) {
+                // Generate a unique ID for the popover element if needed
+                const popoverId = `popover-${this.for}`;
+                this._popoverElement.id = popoverId;
+                // Set popovertarget on the anchor element
+                this._anchorElement.setAttribute("popovertarget", popoverId);
+                this._anchorElement.setAttribute("popovertargetaction", "toggle");
+              }
+            });
+          } else {
+            // Fallback: use click listener for browsers without popover support
+            this._anchorElement.addEventListener("click", this._handleAnchorClick);
+          }
         }
       }
     });
   }
 
+  /**
+   * Cleans up event listeners and CSS properties when disconnected.
+   */
   private _cleanupAnchor(): void {
     if (this._anchorElement) {
       this._anchorElement.removeEventListener("click", this._handleAnchorClick);
       // Remove anchor-name from the element
       this._anchorElement.style.removeProperty("anchor-name");
+      // Remove popovertarget attributes
+      this._anchorElement.removeAttribute("popovertarget");
+      this._anchorElement.removeAttribute("popovertargetaction");
     }
   }
 
+  /**
+   * Handles click on anchor element (fallback mode only).
+   */
   private _handleAnchorClick = (): void => {
     this.show();
   };
 
+  /**
+   * Shows the popover.
+   * Uses native showPopover() API when available, falls back to state toggle.
+   */
   public show(): void {
+    if (this._supportsNativePopover && this._popoverElement) {
+      try {
+        this._popoverElement.showPopover();
+      } catch {
+        // Popover might already be open, ignore error
+      }
+    }
     this._open = true;
     this.dispatchEvent(new CustomEvent("col-cal-show", { bubbles: true, composed: true }));
   }
 
+  /**
+   * Hides the popover.
+   * Uses native hidePopover() API when available, falls back to state toggle.
+   */
   public hide(): void {
+    if (this._supportsNativePopover && this._popoverElement) {
+      try {
+        this._popoverElement.hidePopover();
+      } catch {
+        // Popover might already be hidden, ignore error
+      }
+    }
     this._open = false;
     this.dispatchEvent(new CustomEvent("col-cal-after-hide", { bubbles: true, composed: true }));
   }
 
+  /**
+   * Handles click on backdrop (fallback mode only).
+   * In native mode, the popover auto-dismisses via light-dismiss behavior.
+   */
   private _handleBackdropClick = (): void => {
     this.hide();
   };
 
+  /**
+   * Handles the native 'toggle' event from the Popover API.
+   * This event fires when the popover state changes.
+   */
+  private _handlePopoverToggle = (event: Event): void => {
+    const toggleEvent = event as ToggleEvent;
+    if (toggleEvent.newState === "open") {
+      this._open = true;
+      this.dispatchEvent(new CustomEvent("col-cal-show", { bubbles: true, composed: true }));
+    } else if (toggleEvent.newState === "closed") {
+      this._open = false;
+      this.dispatchEvent(new CustomEvent("col-cal-after-hide", { bubbles: true, composed: true }));
+    }
+  };
+
   render() {
+    // Render different markup based on native popover support
+    if (this._supportsNativePopover) {
+      return this._renderNativePopover();
+    }
+    return this._renderFallbackPopover();
+  }
+
+  /**
+   * Renders the popover using native Popover API.
+   * Uses popover="auto" for automatic light-dismiss behavior.
+   */
+  private _renderNativePopover() {
+    return html`
+      <div
+        class="popover-container"
+        popover="auto"
+        style="--popover-anchor: ${this._anchorName}"
+        data-testid="${this.dataTestid}"
+        @toggle=${this._handlePopoverToggle}
+      >
+        <div class="popover-content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Renders the popover using fallback mechanism for browsers
+   * that don't support the native Popover API.
+   * Uses a backdrop element for light-dismiss behavior.
+   */
+  private _renderFallbackPopover() {
     return html`
       ${this._open
         ? html`<div

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { ColCal } from "./col-cal/col-cal";
 import { getMonths, getWeeks } from "./date.utils";
+import { supportsPopoverAPI } from "./col-cal-popover/col-cal-popover";
 
 export default { ColCal };
 
-export { getMonths, getWeeks };
+export { getMonths, getWeeks, supportsPopoverAPI };


### PR DESCRIPTION
## Summary

This PR refactors the `col-cal-popover` component to leverage the native HTML Popover API for better performance, accessibility, and modern web standards compliance.

- **Uses native `popover="auto"` attribute** for automatic light-dismiss behavior and top-layer rendering
- **Implements `:popover-open` CSS pseudo-selector** for styling the open state of popovers
- **Adds `popovertarget` and `popovertargetaction` attributes** for declarative trigger connection
- **Provides graceful degradation** for browsers without Popover API support using a JavaScript-based fallback
- **Exports `supportsPopoverAPI()` function** for feature detection by consumers

## Technical Implementation

### Native Popover Mode (Chrome 114+, Edge 114+, Safari 17+, Firefox 125+)
- Uses `popover="auto"` for browser-handled light-dismiss
- Leverages the top layer for proper stacking without z-index hacks
- Listens to native `toggle` event for state synchronization
- Uses `showPopover()` and `hidePopover()` methods for programmatic control

### Fallback Mode (Older browsers)
- Maintains existing `data-open` attribute-based visibility toggle
- Uses backdrop element for light-dismiss behavior
- Click event listener on trigger elements

### CSS Improvements
- Uses `:popover-open` pseudo-selector for native popover styling
- Maintains CSS anchor positioning for both modes
- Well-documented CSS with clear separation of native vs fallback styles

## Files Changed
- `src/col-cal-popover/col-cal-popover.ts` - Main popover component with native API integration
- `src/col-cal-popover/col-cal-popover.css.ts` - Updated styles using `:popover-open`
- `src/index.ts` - Export `supportsPopoverAPI` function
- `examples/native-popover-demo.html` - Demo page showing feature detection and usage

## Test plan

- [ ] Verify popover opens/closes correctly on modern browsers (Chrome 114+, Safari 17+)
- [ ] Verify fallback works on older browsers or browsers with popover API disabled
- [ ] Verify month selector popover functions correctly
- [ ] Verify year selector popover functions correctly
- [ ] Verify light-dismiss behavior (clicking outside closes popover)
- [ ] Verify CSS anchor positioning works for both modes
- [ ] Run build to ensure no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes lion-lef/col-cal#3